### PR TITLE
Fixes eager loading products and missing .all() in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Both licenses and products have several eager-loadable properties.
     {% set licenses = craft.digitalProducts
         .licenses
         .owner(currentUser)
-        .with(['products', 'order']) 
+        .with(['products', 'order'])
+        .all()
     %}
 
     <div class="panel panel-default">
@@ -146,7 +147,8 @@ Both licenses and products have several eager-loadable properties.
 {% set products = craft.digitalProducts
     .products
     .type('onlineCourses')
-    .with(['existingLicenses']) 
+    .with(['existingLicenses'])
+    .all()
 %}
 
 {% if products|length %}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Both licenses and products have several eager-loadable properties.
     {% set licenses = craft.digitalProducts
         .licenses
         .owner(currentUser)
-        .with(['products', 'order'])
+        .with(['product', 'order'])
         .all()
     %}
 


### PR DESCRIPTION
This Pull Request:

- Fixes the missing `.all()` in the Twig examples
- Changes “products” to “product” in the Twig eager loading example

Using “product” for the handle appears to be correct to me based on this line: https://github.com/craftcms/digital-products/blob/51e61064425327d80703973d2c4e928da1bba5df/src/elements/License.php#L268

For a customer with 20 orders, using the Twig example from the README:

- With “products,” plural resulted in 59 DB queries
- With “product,” singular resulted in 41 DB queries