### PR TITLE
Remove deletion of `elementindexsettings` table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Digital Products
 
+## Unreleased
+
+- Fixed a PHP error when uninstalling the plugin. ([#80](https://github.com/craftcms/digital-products/issues/80))
+
 ## 3.1.0 - 2022-11-23
 
 ### Fixed

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -2,8 +2,6 @@
 
 namespace craft\digitalproducts\migrations;
 
-use craft\commerce\elements\Order;
-use craft\commerce\elements\Product;
 use craft\db\Migration;
 use craft\digitalproducts\db\Table;
 use craft\helpers\Db;

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -36,8 +36,6 @@ class Install extends Migration
         $this->dropForeignKeys();
         $this->dropTables();
 
-        $this->delete('{{%elementindexsettings}}', ['type' => [Order::class, Product::class]]);
-
         return true;
     }
 


### PR DESCRIPTION
As of [Craft 4](https://github.com/craftcms/cms/commit/bd8a3fdbadd99fb3092cd8e00b051aad7b2c627d) the `elementindexsettings` table isn't present. If you install this plugin on 4.0 and then try to uninstall, the initial uninstall will throw an error when it tries to delete the `elementindexsettings` table. That exception happens in a place where the tables have been removed, but the uninstall wasn't reported as successful. Subsequent uninstall attempts will then throw an error when trying to remove the foreign keys. 

Fixes #80