### PR TITLE
Digital product Licenses permission fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Digital Products
 
+## Unreleased
+
+- Fixed a bug where digital product Licenses couldn’t be edited or deleted in Craft 4.3.2+.
+
 ## 3.2.0 - 2023-01-25
 
 - Product type field layouts now support UI elements. ([#60](https://github.com/craftcms/digital-products/issues/60))

--- a/src/elements/License.php
+++ b/src/elements/License.php
@@ -527,4 +527,48 @@ class License extends Element
 
         parent::prepElementQueryForTableAttribute($elementQuery, $attribute);
     }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function canView(User $user): bool
+    {
+        return $this->_canManageProductType($user);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canSave(User $user): bool
+    {
+        return $this->_canManageProductType($user);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canDelete(User $user): bool
+    {
+        return $this->_canManageProductType($user);
+    }
+
+    /**
+     * @param User $user
+     * @return bool
+     */
+    private function _canManageProductType(User $user): bool
+    {
+        if (parent::canView($user)) {
+            return true;
+        }
+
+        try {
+            $productType = $this->getProductType();
+        } catch (\Exception) {
+            return false;
+        }
+
+        return $user->can('digitalProducts-manageLicenses:' . $productType->uid);
+    }
 }


### PR DESCRIPTION
### Description

Fixed a bug where digital product Licenses couldn’t be edited or deleted in Craft 4.3.2+.


